### PR TITLE
アニメーションをスキップできるように

### DIFF
--- a/src/hackforplay/behavior-types.js
+++ b/src/hackforplay/behavior-types.js
@@ -1,5 +1,6 @@
 const BehaviorTypes = {
   None: null, // 無状態 (デフォルトではEventは発火されません)[deprecated]
+  Init: 'init', // スキン適用時にアニメーションが未定義だった場合のみ使用される（状態ではない）
   Idle: 'idle', // 立ち状態
   Walk: 'walk', // 歩き状態
   Attack: 'attack', // 攻撃状態

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -253,7 +253,7 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     return this._frame as number;
   }
 
-  public set frame(value: number | (number | null)[]) {
+  public set frame(value: number | null | (number | null)[]) {
     // deep compare はしない
     if (this._frame === value || this._frameSequence === value) return;
 

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -118,6 +118,7 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
   private _flyToward?: Vector2; // velocity を動的に決定するための暫定プロパティ (~0.11)
   private _image?: typeof enchant.Surface;
   private _noFilterImage?: typeof enchant.Surface; // filter がかかっていないオリジナルの画像
+  private isBehaviorChanged = false;
 
   public constructor(mod?: (this: RPGObject) => void) {
     super(0, 0);
@@ -787,7 +788,6 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     return this._behavior;
   }
 
-  private isBehaviorChanged = false;
   public set behavior(value) {
     if (typeof value === 'string') {
       this.isBehaviorChanged = true;

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -552,13 +552,14 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     this.behavior = BehaviorTypes.Attack;
     const dx = this.mapX + this.forward.x;
     const dy = this.mapY + this.forward.y;
+    let damageObject: RPGObject
 
     if (this.skill) {
       // アセットをしょうかんする
       this.しょうかんする(this.skill);
     } else {
       // ダメージを与えるオブジェクトを生成する
-      const damageObject = new RPGObject();
+      damageObject = new RPGObject();
       damageObject.damage = this.atk;
       registerServant(this, damageObject);
       damageObject.collider = new SAT.Box(new SAT.V(0, 0), 8, 8).toPolygon();
@@ -568,14 +569,13 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
       } else {
         damageObject.locate(dx, dy);
       }
-      damageObject.setTimeout(
-        () => damageObject.destroy(),
-        this.getFrameLength()
-      );
     }
 
     this.once(enchant.Event.ANIMATION_END, () => {
       this.behavior = BehaviorTypes.Idle;
+      if (damageObject) {
+        damageObject.destroy();
+      }
     });
   }
 

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -265,18 +265,10 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
   }
 
   private computeFrame(direction = this.direction, behavior = this.behavior) {
-    const { _graphicColumn, _width, _image, currentSkin } = this;
+    const { _width, _image, currentSkin } = this;
     if (!_image || !_width || !currentSkin) return;
 
-    // skin.column または動的に計算された column
-    let column = 6;
-    if (typeof _graphicColumn === 'number') {
-      column = _graphicColumn;
-    } else {
-      column = (_image.width / (_width || 32)) | 0;
-    }
-
-    const { frame } = currentSkin;
+    const { frame, column } = currentSkin;
     if (!frame || !(behavior in frame)) return;
     const key = behavior as keyof NonNullable<Skin.ISkin['frame']>;
     const animation = frame[key];

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -96,6 +96,7 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
   public lengthOfView: number = 10; // 自分を起点に何マス先まで find 可能か
   public _mayRotate = false; // 向いている方向に合わせてスプライト自体を回転させるフラグ
   public isInvincible = false; // ダメージを受けなくなるフラグ
+  public currentSkin?: Skin.ISkin; // 適用されているスキン
 
   private _hp?: number;
   private _atk?: number;

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -482,9 +482,9 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     }
   }
 
-  private getFrame() {
-    if (this.getFrameOfBehavior[this.behavior] instanceof Function) {
-      return this.getFrameOfBehavior[this.behavior].call(this);
+  private getFrame(behavior: string = this.behavior) {
+    if (this.getFrameOfBehavior[behavior] instanceof Function) {
+      return this.getFrameOfBehavior[behavior].call(this);
     }
     return [];
   }
@@ -1490,8 +1490,13 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
 
   private applySkin = ((f: (object: RPGObject) => void) => {
     f(this); // スキンを適用
-    let routine = this.getFrameOfBehavior[this.behavior];
-    if (routine) this.frame = routine.call(this); // frame を設定し直す
+    const animation = this.getFrame();
+    if (animation.length > 0) {
+      this.frame = animation;
+    } else {
+      // 初期値として, init アニメーションを適用
+      this.frame = this.getFrame('init');
+    }
     this.rotateIfNeeded();
     return f;
   }).bind(this);

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -249,6 +249,26 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     return Boolean(Camera && Camera.main && Camera.main.target === this);
   }
 
+  public get frame() {
+    return this._frame as number;
+  }
+
+  public set frame(value: number | number[]) {
+    // deep compare はしない
+    if (this._frame === value || this._frameSequence === value) return;
+
+    if (Array.isArray(value)) {
+      // アニメーションを [] にすることで frame の上書きをスキップできる
+      if (value.length < 1) return;
+      (this as any)._frameSequence = value;
+    }
+    if (typeof value === 'number') {
+      (this as any)._frameSequence = null;
+      (this as any)._frame = value;
+      this._computeFramePosition();
+    }
+  }
+
   private updateCollider() {
     this.collider.pos.x = this.x;
     this.collider.pos.y = this.y;

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -253,7 +253,7 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     return this._frame as number;
   }
 
-  public set frame(value: number | number[]) {
+  public set frame(value: number | (number | null)[]) {
     // deep compare はしない
     if (this._frame === value || this._frameSequence === value) return;
 

--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -788,6 +788,8 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
   public get behavior() {
     return this._behavior;
   }
+
+  private isBehaviorChanged = false;
   public set behavior(value) {
     if (typeof value === 'string') {
       this.isBehaviorChanged = true;

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -93,7 +93,6 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
   ); // (x, y) は Sprite の起点 -> Sprite の分を引く, collider の分を足す
   object._graphicColumn = skin.column; // 後方互換性
 
-  // TODO: ６列 or １列で決め打ちしているが, そもそも列数で判断すべきではない
   if (skin.direction === 4) {
     const idleFrames6 = (skin.frame && skin.frame.idle) || [1, 1];
     const walkFrames6 = (skin.frame && skin.frame.walk) || [

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -128,6 +128,8 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
     object.setFrame(BehaviorTypes.Attack, a(...attackFrames, null, 1));
     object.setFrame(BehaviorTypes.Dead, a(...deadFrames, null, 1));
   }
+  // skin の参照を保持する
+  object.currentSkin = skin;
 };
 
 /**

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -46,7 +46,10 @@ export function decode(...args: (number | null)[]): (number | null)[] {
   const array = [];
   for (let index = 0; index < args.length; index += 2) {
     const n = args[index];
-    const l: number = args[index + 1];
+    const l = args[index + 1];
+    if (l === null) {
+      throw new Error('Invalid skin frame: ' + JSON.stringify(args));
+    }
     for (let i = 0; i < l; i++) array.push(n);
   }
   return array;

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -82,7 +82,6 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
   object.collider.setOffset(
     new SAT.V(skin.collider.x - skin.sprite.x, skin.collider.y - skin.sprite.y)
   ); // (x, y) は Sprite の起点 -> Sprite の分を引く, collider の分を足す
-  object._graphicColumn = skin.column; // 後方互換性
 
   // アニメーションの初期値を設定する
   const frame = (skin.frame = skin.frame || {});

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -1,9 +1,8 @@
 import { default as enchant } from '../enchantjs/enchant';
-import RPGObject from './object/object';
 import { default as SAT } from '../lib/sat.min';
-import { default as BehaviorTypes } from './behavior-types';
 import { default as logFunc } from '../mod/logFunc';
 import { fetchText } from './feeles';
+import RPGObject from './object/object';
 
 export interface ISkin {
   name: string;
@@ -55,14 +54,6 @@ export function decode(...args: (number | null)[]): (number | null)[] {
   return array;
 }
 
-const setD6 = (object: RPGObject, behavior: string, frame: any[]) => {
-  object.setFrame(behavior, () =>
-    frame.map(i =>
-      i !== null && i >= 0 ? i + object.direction * object._graphicColumn : i
-    )
-  );
-};
-
 const nope = () => {};
 
 /**
@@ -93,45 +84,24 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
   ); // (x, y) は Sprite の起点 -> Sprite の分を引く, collider の分を足す
   object._graphicColumn = skin.column; // 後方互換性
 
+  // アニメーションの初期値を設定する
+  const frame = (skin.frame = skin.frame || {});
   if (skin.direction === 4) {
-    const idleFrames6 = (skin.frame && skin.frame.idle) || [1, 1];
-    const walkFrames6 = (skin.frame && skin.frame.walk) || [
-      0,
-      3,
-      1,
-      3,
-      2,
-      3,
-      1,
-      1
-    ];
-    const attackFrames6 = (skin.frame && skin.frame.attack) || [
-      3,
-      4,
-      4,
-      4,
-      5,
-      4
-    ];
-    const deadFrames6 = (skin.frame && skin.frame.dead) || [1, 1];
-    // 配列をオブジェクトにセット
     object.directionType = 'quadruple';
-    setD6(object, BehaviorTypes.Idle, decode(...idleFrames6));
-    setD6(object, BehaviorTypes.Walk, decode(...walkFrames6, null, 1));
-    setD6(object, BehaviorTypes.Attack, decode(...attackFrames6, null, 1));
-    setD6(object, BehaviorTypes.Dead, decode(...deadFrames6, null, 1));
+    frame.idle = frame.idle || [1, 1];
+    frame.walk = frame.walk || [0, 3, 1, 3, 2, 3, 1, 1];
+    frame.attack = frame.attack || [3, 4, 4, 4, 5, 4];
+    frame.dead = frame.dead || [1, 1];
   } else {
-    const idleFrames = (skin.frame && skin.frame.idle) || [1, 1];
-    const walkFrames = (skin.frame && skin.frame.walk) || [0, 10];
-    const attackFrames = (skin.frame && skin.frame.attack) || [0, 12];
-    const deadFrames = (skin.frame && skin.frame.dead) || [0, 1];
-    // 配列をオブジェクトにセット
-    object.directionType = 'single';
-    object.setFrame(BehaviorTypes.Idle, decode(...idleFrames));
-    object.setFrame(BehaviorTypes.Walk, decode(...walkFrames, null, 1));
-    object.setFrame(BehaviorTypes.Attack, decode(...attackFrames, null, 1));
-    object.setFrame(BehaviorTypes.Dead, decode(...deadFrames, null, 1));
+    frame.idle = frame.idle || [1, 1];
+    frame.walk = frame.walk || [0, 10];
+    frame.attack = frame.attack || [0, 12];
+    frame.dead = frame.dead || [0, 1];
   }
+  // 互換性のため. アニメーションの終端を追加する
+  frame.walk.push(null, 1);
+  frame.attack.push(null, 1);
+  frame.dead.push(null, 1);
   // skin の参照を保持する
   object.currentSkin = skin;
 };

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -25,10 +25,10 @@ export interface ISkin {
   direction: 1 | 4;
   mayRotate: boolean;
   frame?: {
-    idle?: number[];
-    walk?: number[];
-    attack?: number[];
-    dead?: number[];
+    idle?: (number | null)[];
+    walk?: (number | null)[];
+    attack?: (number | null)[];
+    dead?: (number | null)[];
   };
 }
 export type Result = Promise<(object: RPGObject) => void>;

--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -42,7 +42,7 @@ export const setBaseUrl = (url: string) => {
 const _cache: { [name: string]: Result } = {};
 const _surfaces: { [name: string]: typeof enchant.Surface } = {};
 
-const a = (...args: any[]): any[] => {
+export function decode(...args: (number | null)[]): (number | null)[] {
   const array = [];
   for (let index = 0; index < args.length; index += 2) {
     const n = args[index];
@@ -50,7 +50,7 @@ const a = (...args: any[]): any[] => {
     for (let i = 0; i < l; i++) array.push(n);
   }
   return array;
-};
+}
 
 const setD6 = (object: RPGObject, behavior: string, frame: any[]) => {
   object.setFrame(behavior, () =>
@@ -112,10 +112,10 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
     const deadFrames6 = (skin.frame && skin.frame.dead) || [1, 1];
     // 配列をオブジェクトにセット
     object.directionType = 'quadruple';
-    setD6(object, BehaviorTypes.Idle, a(...idleFrames6));
-    setD6(object, BehaviorTypes.Walk, a(...walkFrames6, null, 1));
-    setD6(object, BehaviorTypes.Attack, a(...attackFrames6, null, 1));
-    setD6(object, BehaviorTypes.Dead, a(...deadFrames6, null, 1));
+    setD6(object, BehaviorTypes.Idle, decode(...idleFrames6));
+    setD6(object, BehaviorTypes.Walk, decode(...walkFrames6, null, 1));
+    setD6(object, BehaviorTypes.Attack, decode(...attackFrames6, null, 1));
+    setD6(object, BehaviorTypes.Dead, decode(...deadFrames6, null, 1));
   } else {
     const idleFrames = (skin.frame && skin.frame.idle) || [1, 1];
     const walkFrames = (skin.frame && skin.frame.walk) || [0, 10];
@@ -123,10 +123,10 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
     const deadFrames = (skin.frame && skin.frame.dead) || [0, 1];
     // 配列をオブジェクトにセット
     object.directionType = 'single';
-    object.setFrame(BehaviorTypes.Idle, a(...idleFrames));
-    object.setFrame(BehaviorTypes.Walk, a(...walkFrames, null, 1));
-    object.setFrame(BehaviorTypes.Attack, a(...attackFrames, null, 1));
-    object.setFrame(BehaviorTypes.Dead, a(...deadFrames, null, 1));
+    object.setFrame(BehaviorTypes.Idle, decode(...idleFrames));
+    object.setFrame(BehaviorTypes.Walk, decode(...walkFrames, null, 1));
+    object.setFrame(BehaviorTypes.Attack, decode(...attackFrames, null, 1));
+    object.setFrame(BehaviorTypes.Dead, decode(...deadFrames, null, 1));
   }
   // skin の参照を保持する
   object.currentSkin = skin;

--- a/src/tmp-skins.ts
+++ b/src/tmp-skins.ts
@@ -41,7 +41,6 @@ for (const { key, fileName, width, height } of avatars) {
       y: -(this.height - unitSize) / 1.2
     };
 
-    this._graphicColumn = 6; // ６列画像に対応
     setFrameD6(this, BehaviorTypes.Idle, [1]);
     setFrameD6(this, BehaviorTypes.Walk, [0, 0, 0, 1, 1, 1, 2, 2, 2, 1, null]);
     setFrameD6(this, BehaviorTypes.Attack, a(3, 4, 4, 4, 5, 4, null, 1));


### PR DESCRIPTION
[![Screenshot from Gyazo](https://gyazo.com/fa1eb68e641932eb8c17cd682c6a1727/raw)](https://gyazo.com/fa1eb68e641932eb8c17cd682c6a1727)

# 検証用 URL
https://www.hackforplay.xyz/works/pVCEyLVSRqrO3HXNRVT8
（ただし、ローカルホストで common を必要とする）

# 目的

> ドラキュラ、概ねうまくいきそうなんだけど、walkとwalkの間に一瞬Idleが入る仕様上？、ドラキュラが一瞬人状態に戻ってしまう。
> できれば移動中はずっとコウモリの見た目でいてほしい

- ドラキュラの問題は、ドラキュラの `idle` を空の配列にすることで、例外的に対応する。アニメーションが空の配列だった場合、 `frame` は変化しない（その処理がスキップされる）
- ただ、この方法だと一番最初のフレームが規定されないため、 `frame.init` というプロパティを新たに追加する
- ドラキュラの場合だと `frame: { init: [6] }`

# 実装

- `this.frame = []` が代入されたとき、処理をスキップ（見た目は同じままになる）
- `this.costume()` が実行された時点でのアニメーションが `[]` だったなら、例外的に `init` のアニメーションをセットする
