### PR TITLE
fix: へんしんしたときに(15,10)に何かが残り続けるバグを修正

### DIFF
--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -39,6 +39,7 @@ import { showThinkSprite } from '../think';
 import { registerWalkingObject, unregisterWalkingObject } from '../trodden';
 import { observeArray } from '../utils/observe-array';
 import * as N from './numbers';
+import { getTransformDefaultProps } from './transform-default-props';
 
 const Hack = getHack();
 
@@ -64,33 +65,16 @@ const followingPlayerObjects = new WeakSet<RPGObject>();
 const opt = <T>(opt: T | undefined, def: T): T =>
   opt !== undefined ? opt : def;
 
-const uniqId = (i => () => ++i)(0);
+const uniqId = (
+  i => () =>
+    ++i
+)(0);
 
 export default class RPGObject extends enchant.Sprite implements N.INumbers {
   // RPGObject.collection に必要な初期化
   private static _collectionTarget = [RPGObject];
   public static collection = observeArray<RPGObject>([]); // Proxy でトラップする
   private static _collective = true;
-  // へんしんするときに初期化するプロパティの設定
-  private static readonly propNamesToInit = [
-    // 初期値で上書きしたいプロパティ
-    'damage',
-    'speed',
-    'opacity',
-    'velocityX',
-    'velocityY',
-    'accelerationX',
-    'accelerationY',
-    'mass',
-    'skill',
-    'fieldOfView',
-    'lengthOfView',
-    // 未初期化状態に戻したいプロパティ
-    '_atk',
-    '_penetrate',
-    '_collisionFlag',
-    '_isKinematic'
-  ];
 
   public offset = {
     x: 0,
@@ -1253,19 +1237,13 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
     return this.しょうかんする(name, 0, 0);
   }
 
-  private static _initializedReference: RPGObject;
   public transform(name: string) {
     const { _ruleInstance, _hp } = this;
     if (!_ruleInstance) return;
 
-    // 初期値を参照するためのインスタンスを作る
-    RPGObject._initializedReference =
-      RPGObject._initializedReference || new RPGObject();
-
     // 一部のパラメータを初期値に戻す
-    for (const key of RPGObject.propNamesToInit) {
-      this[key] = RPGObject._initializedReference[key];
-    }
+    const props = getTransformDefaultProps();
+    Object.assign(this, props);
 
     _ruleInstance.installAsset(name);
     _ruleInstance.unregisterRules(this);

--- a/src/hackforplay/object/transform-default-props.test.ts
+++ b/src/hackforplay/object/transform-default-props.test.ts
@@ -1,0 +1,23 @@
+import test from 'ava';
+import { getTransformDefaultProps } from './transform-default-props';
+
+test('getTransformDefaultProps', t => {
+  const props = getTransformDefaultProps();
+  t.deepEqual(props, {
+    _atk: undefined,
+    _collisionFlag: undefined,
+    _isKinematic: undefined,
+    _penetrate: undefined,
+    damage: 0,
+    speed: 1,
+    opacity: 1,
+    velocityX: 0,
+    velocityY: 0,
+    accelerationX: 0,
+    accelerationY: 0,
+    mass: 1,
+    skill: '',
+    fieldOfView: 1,
+    lengthOfView: 10
+  });
+});

--- a/src/hackforplay/object/transform-default-props.ts
+++ b/src/hackforplay/object/transform-default-props.ts
@@ -1,0 +1,44 @@
+import RPGObject from './object';
+
+/* へんしんするときに初期化するプロパティ名 */
+const propNamesToInit = [
+  // 初期値で上書きしたいプロパティ
+  'damage',
+  'speed',
+  'opacity',
+  'velocityX',
+  'velocityY',
+  'accelerationX',
+  'accelerationY',
+  'mass',
+  'skill',
+  'fieldOfView',
+  'lengthOfView',
+  // 未初期化状態に戻したいプロパティ
+  '_atk',
+  '_penetrate',
+  '_collisionFlag',
+  '_isKinematic'
+] as const;
+
+let transformDefaultProps:
+  | undefined
+  | Pick<RPGObject, typeof propNamesToInit[number]> = undefined;
+
+/** へんしんする時に初期化するプロパティとその値 */
+export function getTransformDefaultProps() {
+  if (!transformDefaultProps) {
+    const defaultObject = new RPGObject();
+    transformDefaultProps = pick(defaultObject, propNamesToInit);
+    defaultObject.destroy();
+  }
+  return transformDefaultProps;
+}
+
+function pick<T, K extends keyof T>(object: T, keys: readonly K[]) {
+  const result: any = {};
+  for (const key of keys) {
+    result[key] = object[key];
+  }
+  return result as Pick<T, K>;
+}


### PR DESCRIPTION
[https://scrapbox.io/hackforplay-inc/this.へんしんする()するとマップの15,10に謎の当たり判定が発生する](https://scrapbox.io/hackforplay-inc/this.%E3%81%B8%E3%82%93%E3%81%97%E3%82%93%E3%81%99%E3%82%8B()%E3%81%99%E3%82%8B%E3%81%A8%E3%83%9E%E3%83%83%E3%83%97%E3%81%AE15,10%E3%81%AB%E8%AC%8E%E3%81%AE%E5%BD%93%E3%81%9F%E3%82%8A%E5%88%A4%E5%AE%9A%E3%81%8C%E7%99%BA%E7%94%9F%E3%81%99%E3%82%8B)を修正しました