### PR TITLE
BK: 違うマップにいるキャラクターがぶつかってくるバグを修正

### DIFF
--- a/src/hackforplay/object/object.ts
+++ b/src/hackforplay/object/object.ts
@@ -690,10 +690,16 @@ export default class RPGObject extends enchant.Sprite implements N.INumbers {
       nextMapY < 0 ||
       nextMapY >= ty; // 画面外にいこうとしている
 
+    // 同じマップにいるオブジェクト
+    const currentMap = this.map;
+    const objectsInSameMap = RPGObject.collection.filter(
+      obj => obj.map === currentMap
+    );
+
     // プレイヤーだけは例外的に仲間のいるマスをすり抜けられる
     const mayCollideItems = this.isPlayer
-      ? objectsInDefaultMap().filter(item => this.family !== item.family)
-      : objectsInDefaultMap();
+      ? objectsInSameMap.filter(item => this.family !== item.family)
+      : objectsInSameMap;
 
     // 歩く先にあるオブジェクト
     const hits = mayCollideItems.filter(obj => {

--- a/src/hackforplay/rule.ts
+++ b/src/hackforplay/rule.ts
@@ -1,16 +1,17 @@
 import { log } from '@hackforplay/log';
+import { objectsInDefaultMap } from './cache';
 import { IDir } from './dir';
 import { Direction } from './direction';
 import { hasContract, isOpposite } from './family';
 import { install } from './feeles';
 import { getHack } from './get-hack';
 import { emitGlobalsChangedIfNeeded } from './globals';
+import { loadMaps } from './load-maps';
 import RPGObject from './object/object';
 import { errorInEvent, logFromAsset } from './stdlog';
 import { synonyms } from './synonyms/rule';
 import { PropertyMissing, synonymizeClass } from './synonyms/synonymize';
 import talk from './talk';
-import { loadMaps } from './load-maps';
 
 interface IEvent {
   target: RPGObject;
@@ -314,8 +315,7 @@ export class Rule {
     if (!Hack.isPlaying) return; // ゲームが終了した
 
     // つねに をコールする
-    // this._collections を使うべきか？（へんしんしたときちゃんと動くか？）
-    for (const object of Array.from(RPGObject.collection)) {
+    for (const object of objectsInDefaultMap()) {
       if (!this.enabledUpdate.get(object)) {
         continue; // まだ途中になっているものがある => スキップ
       }

--- a/src/hackforplay/rule.ts
+++ b/src/hackforplay/rule.ts
@@ -385,6 +385,9 @@ export class Rule {
     if (!listeners) return;
     for (const name of Object.keys(listeners)) {
       for (const item of this.getCollection(name)) {
+        const map = 'map' in Hack ? Hack.map : undefined;
+        if (item.map !== map) continue; // プレイヤーと同じマップにいるものだけが対象
+
         this.scheduleEventEmit({
           eventName: 'じかんがすすんだとき',
           args: [item]


### PR DESCRIPTION
[https://scrapbox.io/hackforplay-inc/別のマップにいるキャラクターにぶつかられるバグ](https://scrapbox.io/hackforplay-inc/%E5%88%A5%E3%81%AE%E3%83%9E%E3%83%83%E3%83%97%E3%81%AB%E3%81%84%E3%82%8B%E3%82%AD%E3%83%A3%E3%83%A9%E3%82%AF%E3%82%BF%E3%83%BC%E3%81%AB%E3%81%B6%E3%81%A4%E3%81%8B%E3%82%89%E3%82%8C%E3%82%8B%E3%83%90%E3%82%B0)を修正しました。

この修正にはBREAKING CHANGESが含まれます
- プレイヤーと違うマップにいるオブジェクトは、つねにとじかんがすすんだときを呼ばない
- あるくの当たり判定を、「自分と同じマップにいるかどうか」に変更する