### PR TITLE
みためを何度も変えると攻撃後にラグができるバグを修正

### DIFF
--- a/src/hackforplay/skin.ts
+++ b/src/hackforplay/skin.ts
@@ -66,10 +66,19 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
     new SAT.V(skin.collider.x - skin.sprite.x, skin.collider.y - skin.sprite.y)
   ); // (x, y) は Sprite の起点 -> Sprite の分を引く, collider の分を足す
 
+  if (skin.direction === 4) {
+    object.directionType = 'quadruple';
+  }
+
+  // skin の参照を保持する
+  object.currentSkin = skin;
+};
+
+/** skin設定に与えられていない情報を補完する。破壊的なメソッド */
+function fixSkinData(skin: OutputV1) {
   // アニメーションの初期値を設定する
   const frame = (skin.frame = skin.frame || {});
   if (skin.direction === 4) {
-    object.directionType = 'quadruple';
     frame.idle = frame.idle || [1, 1];
     frame.walk = frame.walk || [0, 3, 1, 3, 2, 3, 1, 1];
     frame.attack = frame.attack || [3, 4, 4, 4, 5, 4];
@@ -83,9 +92,7 @@ export const dress = (skin: ISkin) => (object: RPGObject) => {
   // 互換性のため. アニメーションの終端を追加する
   frame.attack?.push(null, 1);
   frame.dead?.push(null, 1);
-  // skin の参照を保持する
-  object.currentSkin = skin;
-};
+}
 
 export async function getSkin(
   input: string | TemplateStringsArray
@@ -107,6 +114,7 @@ export async function getSkin(
       item.sprite.height * item.row,
       definition.endpoint + item.imageUri
     );
+    fixSkinData(item);
     // V0 では JSON のロードを待っていたが、V1 では preload してあるので即時コール
     return dress({ ...item, name, surface });
   });


### PR DESCRIPTION
見た目を何度も変えると攻撃後にラグができるバグがあったので修正した

https://www.hackforplay.xyz/works/4kYiJ9GAqQXK5l2GWRW7/edit

https://github.com/hackforplay/common/assets/6120593/dba3afe9-dee6-4be3-b9f7-5f060235e988

# 原因

互換性保持のための `frame.attack.push([null, 1])` が「みためをかえる」度に呼ばれていた

# 修正方法

初期ロード時に一度だけ上記処理を行うように変更した
